### PR TITLE
Fix a typo in utils.gml

### DIFF
--- a/code to add/utils.gml
+++ b/code to add/utils.gml
@@ -568,7 +568,7 @@ function preloadCustomLevel(argument0)
     instanceManager_reset()
 }
 
-function loadCustomLevel(argument0, argument1, argument2) // level name, wether it's instant or not, reset level complete
+function loadCustomLevel(argument0, argument1, argument2) // level name, whether it's instant or not, reset level complete
 {
     preloadCustomLevel(argument0)
     


### PR DESCRIPTION
I was looking at the AFOM source and I came across a typo. I saw this and said to myself "This is unacceptable. I must fix this objects mod." I have made a pull request to fix the typo so that the mod will be playable again.